### PR TITLE
Feature feed

### DIFF
--- a/Project_SakaMaka/Source/View/Feed/ViewController/FeedViewController.swift
+++ b/Project_SakaMaka/Source/View/Feed/ViewController/FeedViewController.swift
@@ -78,13 +78,11 @@ class FeedViewController: BaseViewController {
                 let isUnliked = self?.viewModel.isCurrentUserUnlikedPost(postId: item.id)
 
                 cell.onVoteBuyButtonTapped = { [weak self] in
-                    self?.viewModel.voteBuyButtonTapped.onNext(())
-                    self?.viewModel.postId.onNext(item.id)
+                    self?.viewModel.voteBuyButtonTapped.onNext((item.id, "like"))
                 }
                 
                 cell.onVoteDontBuyButtonTapped = { [weak self] in
-                    self?.viewModel.voteDontBuyButtonTapped.onNext(())
-                    self?.viewModel.postId.onNext(item.id)
+                    self?.viewModel.voteDontBuyButtonTapped.onNext((item.id, "unlike"))
                 }
                 
                 cell.configuration(item)

--- a/Project_SakaMaka/Source/View/Feed/ViewModel/FeedViewModel.swift
+++ b/Project_SakaMaka/Source/View/Feed/ViewModel/FeedViewModel.swift
@@ -14,8 +14,8 @@ import FirebaseFirestore
 
 protocol FeedViewModelType {
     // Input
-    var voteBuyButtonTapped: AnyObserver<Void> { get }
-    var voteDontBuyButtonTapped: AnyObserver<Void> { get }
+    var voteBuyButtonTapped: AnyObserver<(String, String)> { get }
+    var voteDontBuyButtonTapped: AnyObserver<(String, String)> { get }
     var postId: AnyObserver<String> { get }
     
     // Output
@@ -31,8 +31,8 @@ class FeedViewModel {
     private let disposeBag = DisposeBag()
     
     // Input
-    private let inputVoteBuyButtonTapped = PublishSubject<Void>()
-    private let inputVoteDontBuyButtonTapped = PublishSubject<Void>()
+    private let inputVoteBuyButtonTapped = PublishSubject<(String, String)>()
+    private let inputVoteDontBuyButtonTapped = PublishSubject<(String, String)>()
     private let inputPostId = PublishSubject<String>()
     private let inputPost = PublishSubject<Post>()
     
@@ -47,21 +47,17 @@ class FeedViewModel {
     }
 
     private func likeVote() {
-        let voteBuyButtonTappedWithPostId = Observable.zip(inputVoteBuyButtonTapped, inputPostId)
-        
-        voteBuyButtonTappedWithPostId
-            .subscribe(onNext: { _, id in
-                FireBaseService.shared.vote(postId: id, vote: "like")
+        inputVoteBuyButtonTapped
+            .subscribe(onNext: { id, type in
+                FireBaseService.shared.vote(postId: id, vote: type)
             })
             .disposed(by: disposeBag)
     }
     
     private func unlikeVote() {
-        let voteDontBuyButtonTappedWithPostId = Observable.zip(inputVoteDontBuyButtonTapped, inputPostId)
-        
-        voteDontBuyButtonTappedWithPostId
-            .subscribe(onNext: { _, id in
-                FireBaseService.shared.vote(postId: id, vote: "unlike")
+        inputVoteDontBuyButtonTapped
+            .subscribe(onNext: { id, type in
+                FireBaseService.shared.vote(postId: id, vote: type)
             })
             .disposed(by: disposeBag)
     }
@@ -88,11 +84,11 @@ class FeedViewModel {
 }
 
 extension FeedViewModel: FeedViewModelType {
-    var voteBuyButtonTapped: AnyObserver<Void> {
+    var voteBuyButtonTapped: AnyObserver<(String, String)> {
         inputVoteBuyButtonTapped.asObserver()
     }
     
-    var voteDontBuyButtonTapped: AnyObserver<Void> {
+    var voteDontBuyButtonTapped: AnyObserver<(String, String)> {
         inputVoteDontBuyButtonTapped.asObserver()
     }
     


### PR DESCRIPTION
CHORE FeedViewModel : 기존에 버튼 Tap의 void이벤트와, postID의 String 이벤트를 zip해서 사용 -> 원하지 않는 포스트의 버튼이 같이 Tap되는 문제 발생 -> 버튼 클릭 이벤트가 잘못된 'postId'와 연결되어 있어서 발생 함 -> 이벤트 처리 방식 수정

CHORE FeedViewController : 이벤트 처리 방식이 수정 됨에 따라 viewModel에 바인드 하는 방식 수정